### PR TITLE
Demonstrate OpenTelemetry extension as a transform

### DIFF
--- a/Expecto.Tests/Expecto.Tests.fsproj
+++ b/Expecto.Tests/Expecto.Tests.fsproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>Expecto.Tests</AssemblyName>
@@ -13,6 +13,7 @@
     <Compile Include="FsCheckTests.fs" />
     <Compile Include="PerformanceTests.fs" />
     <Compile Include="Bug341.fs" />
+    <Compile Include="OpenTelemetry.fs" />
     <Compile Include="Main.fs" />
     <None Include="paket.references" />
     <ProjectReference Include="..\Expecto.Hopac\Expecto.Hopac.fsproj" />

--- a/Expecto.Tests/Main.fs
+++ b/Expecto.Tests/Main.fs
@@ -36,8 +36,9 @@ let main args =
   let test =
     Impl.testFromThisAssembly()
     |> Option.orDefault (TestList ([], Normal))
+    |> OpenTelemetry.addOpenTelemetry_SpanPerTest Impl.ExpectoConfig.defaultConfig activitySource
     |> Test.shuffle "."
-  runTestsWithCLIArgs [NUnit_Summary "bin/Expecto.Tests.TestResults.xml"; CLIArguments.ActivitySource activitySource] args test
+  runTestsWithCLIArgs [NUnit_Summary "bin/Expecto.Tests.TestResults.xml"] args test
 
 
 

--- a/Expecto.Tests/OpenTelemetry.fs
+++ b/Expecto.Tests/OpenTelemetry.fs
@@ -1,0 +1,290 @@
+namespace Expecto
+
+module OpenTelemetry =
+  open System
+  open System.Diagnostics
+  open System.Collections.Generic
+  open System.Threading
+  open Impl
+
+  module internal Activity =
+    let inline setStatus (status : ActivityStatusCode) (span : Activity) =
+      if isNull span |> not then
+        span.SetStatus(status) |> ignore
+
+    let inline setExn (e : exn) (span : Activity) =
+      if isNull span |> not then
+        let tags =
+            ActivityTagsCollection(
+                seq {
+                    KeyValuePair("exception.type", box (e.GetType().Name))
+                    KeyValuePair("exception.stacktrace", box (e.ToString()))
+                    if not <| String.IsNullOrEmpty(e.Message) then
+                        KeyValuePair("exception.message", box e.Message)
+                }
+            )
+
+        ActivityEvent("exception", tags = tags)
+        |> span.AddEvent
+        |> ignore
+
+    let inline setExnMarkFailed (e : exn) (span : Activity) =
+      if isNull span |> not then
+        setExn e span
+        span  |> setStatus ActivityStatusCode.Error
+
+    let setSourceLocation (sourceLoc : SourceLocation) (span : Activity) =
+      if isNull span |> not && sourceLoc <> SourceLocation.empty then
+        span.SetTag("code.lineno", sourceLoc.lineNumber) |> ignore
+        span.SetTag("code.filepath", sourceLoc.sourcePath) |> ignore
+
+    let inline addOutcome (result : TestResult) (span : Activity) =
+      if isNull span |> not then
+        span.SetTag("test.result.status", result.tag) |> ignore
+        span.SetTag("test.result.message", result) |> ignore
+
+    let inline start (span : Activity) =
+      if isNull span |> not then
+        span.Start() |> ignore
+      span
+
+    let inline stop (span : Activity) =
+      if isNull span |> not then
+        span.Stop() |> ignore
+
+    let inline createActivity (name : string) (source : ActivitySource option) =
+      match source with
+      | Some source when not(isNull source) -> source.CreateActivity(name, ActivityKind.Internal)
+      | _ -> null
+
+  open Activity
+
+  open System.Runtime.ExceptionServices
+
+  let inline internal reraiseAnywhere<'a> (e: exn) : 'a =
+      ExceptionDispatchInfo.Capture(e).Throw()
+      Unchecked.defaultof<'a>
+
+  let wrapCodeWithSpan (span: Activity) (test: TestCode) =
+    match test with
+    | Sync test ->
+      TestCode.Sync (fun () ->
+        try
+          start span
+          test ()
+          stop span
+          addOutcome Passed span
+          setStatus ActivityStatusCode.Ok span
+        with
+        | :? AssertException as e ->
+          stop span
+          // TODO: this message construction is fragile duplication
+          let msg =
+            "\n" + e.Message + "\n" +
+            (e.StackTrace.Split('\n')
+            |> Seq.skipWhile (fun l -> l.StartsWith("   at Expecto.Expect."))
+            |> Seq.truncate 5
+            |> String.concat "\n")
+          let result = Failed msg
+          addOutcome result span
+          setExnMarkFailed e span
+          reraiseAnywhere e
+        | :? FailedException as e ->
+          stop span
+          let result = Failed ("\n"+e.Message)
+          addOutcome result span
+          setExnMarkFailed e span
+          reraiseAnywhere e
+        | :? IgnoreException as e ->
+          stop span
+          let result = Ignored e.Message
+          addOutcome result span
+          setExn e span
+          reraiseAnywhere e
+        | :? AggregateException as e when e.InnerExceptions.Count = 1 ->
+          stop span
+          if e.InnerException :? IgnoreException then
+            let result = Ignored e.InnerException.Message
+            addOutcome result span
+            setExn e span
+          else
+            let result = Error e.InnerException
+            addOutcome result span
+            setExnMarkFailed e span
+          reraiseAnywhere e
+        | e ->
+          stop span
+          let result = Error e
+          addOutcome result span
+          setExnMarkFailed e span
+          reraiseAnywhere e
+      )
+
+    | Async test ->
+      TestCode.Async (async {
+        try
+          start span
+          do! test
+          stop span
+          addOutcome Passed span
+          setStatus ActivityStatusCode.Ok span
+        with
+        | :? AssertException as e ->
+          stop span
+          // TODO: this message construction is fragile duplication
+          let msg =
+            "\n" + e.Message + "\n" +
+            (e.StackTrace.Split('\n')
+            |> Seq.skipWhile (fun l -> l.StartsWith("   at Expecto.Expect."))
+            |> Seq.truncate 5
+            |> String.concat "\n")
+          let result = Failed msg
+          addOutcome result span
+          setExnMarkFailed e span
+          reraiseAnywhere e
+        | :? FailedException as e ->
+          stop span
+          let result = Failed ("\n"+e.Message)
+          addOutcome result span
+          setExnMarkFailed e span
+          reraiseAnywhere e
+        | :? IgnoreException as e ->
+          stop span
+          let result = Ignored e.Message
+          addOutcome result span
+          setExn e span
+          reraiseAnywhere e
+        | :? AggregateException as e when e.InnerExceptions.Count = 1 ->
+          stop span
+          if e.InnerException :? IgnoreException then
+            let result = Ignored e.InnerException.Message
+            addOutcome result span
+            setExn e span
+          else
+            let result = Error e.InnerException
+            addOutcome result span
+            setExnMarkFailed e span
+          reraiseAnywhere e
+        | e ->
+          stop span
+          let result = Error e
+          addOutcome result span
+          setExnMarkFailed e span
+          reraiseAnywhere e
+      })
+    | AsyncFsCheck (testConfig, stressConfig, test) ->
+      TestCode.AsyncFsCheck (testConfig, stressConfig, fun fsCheckConfig -> async {
+        try
+          start span
+          do! test fsCheckConfig
+          stop span
+          addOutcome Passed span
+          setStatus ActivityStatusCode.Ok span
+        with
+        | :? AssertException as e ->
+          stop span
+          // TODO: this message construction is fragile duplication
+          let msg =
+            "\n" + e.Message + "\n" +
+            (e.StackTrace.Split('\n')
+            |> Seq.skipWhile (fun l -> l.StartsWith("   at Expecto.Expect."))
+            |> Seq.truncate 5
+            |> String.concat "\n")
+          let result = Failed msg
+          addOutcome result span
+          setExnMarkFailed e span
+          reraiseAnywhere e
+        | :? FailedException as e ->
+          stop span
+          let result = Failed ("\n"+e.Message)
+          addOutcome result span
+          setExnMarkFailed e span
+          reraiseAnywhere e
+        | :? IgnoreException as e ->
+          stop span
+          let result = Ignored e.Message
+          addOutcome result span
+          setExn e span
+          reraiseAnywhere e
+        | :? AggregateException as e when e.InnerExceptions.Count = 1 ->
+          stop span
+          if e.InnerException :? IgnoreException then
+            let result = Ignored e.InnerException.Message
+            addOutcome result span
+            setExn e span
+          else
+            let result = Error e.InnerException
+            addOutcome result span
+            setExnMarkFailed e span
+          reraiseAnywhere e
+        | e ->
+          stop span
+          let result = Error e
+          addOutcome result span
+          setExnMarkFailed e span
+          reraiseAnywhere e
+      })
+    | SyncWithCancel test->
+      TestCode.SyncWithCancel (fun ct ->
+        try
+          start span
+          test ct
+          stop span
+          addOutcome Passed span
+          setStatus ActivityStatusCode.Ok span
+        with
+        | :? AssertException as e ->
+          stop span
+          // TODO: this message construction is fragile duplication
+          let msg =
+            "\n" + e.Message + "\n" +
+            (e.StackTrace.Split('\n')
+            |> Seq.skipWhile (fun l -> l.StartsWith("   at Expecto.Expect."))
+            |> Seq.truncate 5
+            |> String.concat "\n")
+          let result = Failed msg
+          addOutcome result span
+          setExnMarkFailed e span
+          reraiseAnywhere e
+        | :? FailedException as e ->
+          stop span
+          let result = Failed ("\n"+e.Message)
+          addOutcome result span
+          setExnMarkFailed e span
+          reraiseAnywhere e
+        | :? IgnoreException as e ->
+          stop span
+          let result = Ignored e.Message
+          addOutcome result span
+          setExn e span
+          reraiseAnywhere e
+        | :? AggregateException as e when e.InnerExceptions.Count = 1 ->
+          stop span
+          if e.InnerException :? IgnoreException then
+            let result = Ignored e.InnerException.Message
+            addOutcome result span
+            setExn e span
+          else
+            let result = Error e.InnerException
+            addOutcome result span
+            setExnMarkFailed e span
+          reraiseAnywhere e
+        | e ->
+          stop span
+          let result = Error e
+          addOutcome result span
+          setExnMarkFailed e span
+          reraiseAnywhere e
+      )
+
+
+  let addOpenTelemetry_SpanPerTest (config: ExpectoConfig) (activitySource: ActivitySource) (rootTest: Test) : Test =
+
+    rootTest
+    |> Test.toTestCodeList
+    |> List.map (fun test ->
+      let span = createActivity (config.joinWith.format test.name) (Some activitySource)
+      span |> setSourceLocation (config.locate test.test)
+      {test with test = wrapCodeWithSpan span test.test}
+    )
+    |> Test.fromFlatTests config.joinWith.asString

--- a/Expecto/Expecto.Impl.fs
+++ b/Expecto/Expecto.Impl.fs
@@ -580,63 +580,8 @@ module Impl =
               }
       }
 
-  let inline internal setStatus (status : ActivityStatusCode) (span : Activity) =
-    if isNull span |> not then
-      span.SetStatus(status) |> ignore
-
-  let inline internal setExn (e : exn) (span : Activity) =
-    if isNull span |> not then
-      let tags =
-          ActivityTagsCollection(
-              seq {
-                  KeyValuePair("exception.type", box (e.GetType().Name))
-                  KeyValuePair("exception.stacktrace", box (e.ToString()))
-                  if not <| String.IsNullOrEmpty(e.Message) then
-                      KeyValuePair("exception.message", box e.Message)
-              }
-          )
-
-      ActivityEvent("exception", tags = tags)
-      |> span.AddEvent
-      |> ignore
-
-  let inline internal setExnMarkFailed (e : exn) (span : Activity) =
-    if isNull span |> not then
-      setExn e span
-      span  |> setStatus ActivityStatusCode.Error
-
-  let setSourceLocation (sourceLoc : SourceLocation) (span : Activity) =
-    if isNull span |> not && sourceLoc <> SourceLocation.empty then
-      span.SetTag("code.lineno", sourceLoc.lineNumber) |> ignore
-      span.SetTag("code.filepath", sourceLoc.sourcePath) |> ignore
-
-  let inline internal addOutcome (result : TestResult) (span : Activity) =
-    if isNull span |> not then
-      span.SetTag("test.result.status", result.tag) |> ignore
-      span.SetTag("test.result.message", result) |> ignore
-
-  let inline internal  start (span : Activity) =
-    if isNull span |> not then
-      span.Start() |> ignore
-    span
-
-  let inline internal stop (span : Activity) =
-    if isNull span |> not then
-      span.Stop() |> ignore
-
-  let inline internal createActivity (name : string) (source : ActivitySource option) =
-    match source with
-    | Some source when not(isNull source) -> source.CreateActivity(name, ActivityKind.Internal)
-    | _ -> null
-
   let execTestAsync (ct:CancellationToken) config (test:FlatTest) : Async<TestSummary> =
     async {
-      let span =
-        config.activitySource
-        |> createActivity (config.joinWith.format test.name)
-      span |> setSourceLocation (config.locate test.test)
-
-      use span = start span
       let w = Stopwatch.StartNew()
       try
         match test.shouldSkipEvaluation with
@@ -669,59 +614,32 @@ module Impl =
                 )
             do! test fsConfig
           w.Stop()
-          stop span
-          let result = Passed
-          addOutcome result span
-          setStatus ActivityStatusCode.Ok span
-          return TestSummary.single result (float w.ElapsedMilliseconds)
+          return TestSummary.single Passed (float w.ElapsedMilliseconds)
       with
         | :? AssertException as e ->
           w.Stop()
-          stop span
           let msg =
             "\n" + e.Message + "\n" +
             (e.StackTrace.Split('\n')
              |> Seq.skipWhile (fun l -> l.StartsWith("   at Expecto.Expect."))
              |> Seq.truncate 5
              |> String.concat "\n")
-          let result = Failed msg
-          addOutcome result span
-          setExnMarkFailed e span
-          return TestSummary.single result (float w.ElapsedMilliseconds)
+          return TestSummary.single (Failed msg) (float w.ElapsedMilliseconds)
         | :? FailedException as e ->
           w.Stop()
-          stop span
-          let result = Failed ("\n"+e.Message)
-          addOutcome result span
-          setExnMarkFailed e span
-          return TestSummary.single result (float w.ElapsedMilliseconds)
+          return TestSummary.single (Failed ("\n"+e.Message)) (float w.ElapsedMilliseconds)
         | :? IgnoreException as e ->
           w.Stop()
-          stop span
-          let result = Ignored e.Message
-          addOutcome result span
-          setExn e span
-          return TestSummary.single result (float w.ElapsedMilliseconds)
+          return TestSummary.single (Ignored e.Message) (float w.ElapsedMilliseconds)
         | :? AggregateException as e when e.InnerExceptions.Count = 1 ->
           w.Stop()
-          stop span
           if e.InnerException :? IgnoreException then
-            let result = Ignored e.InnerException.Message
-            addOutcome result span
-            setExn e span
-            return TestSummary.single result (float w.ElapsedMilliseconds)
+            return TestSummary.single (Ignored e.InnerException.Message) (float w.ElapsedMilliseconds)
           else
-            let result = Error e.InnerException
-            addOutcome result span
-            setExnMarkFailed e span
-            return TestSummary.single result (float w.ElapsedMilliseconds)
+            return TestSummary.single (Error e.InnerException) (float w.ElapsedMilliseconds)
         | e ->
           w.Stop()
-          stop span
-          let result = Error e
-          addOutcome result span
-          setExnMarkFailed e span
-          return TestSummary.single result (float w.ElapsedMilliseconds)
+          return TestSummary.single (Error e) (float w.ElapsedMilliseconds)
     }
 
   let private numberOfWorkers limit config =


### PR DESCRIPTION
Here's an idea for how to generically extend expecto instead of baking in Open Telemetry 

The basic idea is to map the Test tree, wrapping the internal test lambda with another function that manages the span.

A few current problems include
- messy and repetitive code wrapper because of the different TestCode varieties
- duplication of mapping exception types to TestResults (including some error message formatting)
- A bit of reliance on ExpectoConfig / settings decided elsewhere (just joinWith and locate). ExpectoConfig is effectively internal now. 


With a bit of work, I think this general approach could be smoothed out and maybe also used to decouple stress testing and FsCheck from the core library.


Thoughts?